### PR TITLE
Add required option to field definitions

### DIFF
--- a/daybed/schemas/base.py
+++ b/daybed/schemas/base.py
@@ -3,6 +3,7 @@ import datetime
 
 from colander import (
     deferred,
+    null,
     SchemaNode,
     Mapping,
     String,
@@ -93,12 +94,15 @@ registry = TypeRegistry()
 
 class TypeField(object):
     node = String
+    required = True
+    default_value = null
 
     @classmethod
     def definition(cls):
         schema = SchemaNode(Mapping())
         schema.add(SchemaNode(String(), name='name'))
         schema.add(SchemaNode(String(), name='description', missing=''))
+        schema.add(SchemaNode(Boolean(), name='required', missing=cls.required))
         schema.add(SchemaNode(String(), name='type',
                               validator=OneOf(registry.names)))
         return schema
@@ -108,6 +112,9 @@ class TypeField(object):
         keys = ['name', 'description', 'validator', 'missing']
         specified = [key for key in keys if key in kwargs.keys()]
         options = dict(zip(specified, [kwargs.get(k) for k in specified]))
+        # If field is not required, use missing
+        if not kwargs.get('required', cls.required):
+            options.setdefault('missing', cls.default_value)
         return SchemaNode(cls.node(), **options)
 
 

--- a/daybed/schemas/base.py
+++ b/daybed/schemas/base.py
@@ -263,7 +263,7 @@ class AutoNowMixin(object):
     def validation(cls, **kwargs):
         auto_now = kwargs.get('auto_now', cls.auto_now)
         if auto_now:
-            kwargs['missing'] = cls.default_value
+            kwargs['missing'] = cls.auto_value
         return super(AutoNowMixin, cls).validation(**kwargs).bind()
 
 
@@ -273,7 +273,7 @@ class DateField(AutoNowMixin, TypeField):
     node = Date
 
     @deferred
-    def default_value(node, kw):
+    def auto_value(node, kw):
         return datetime.date.today()
 
 
@@ -283,5 +283,5 @@ class DateTimeField(AutoNowMixin, TypeField):
     node = DateTime
 
     @deferred
-    def default_value(node, kw):
+    def auto_value(node, kw):
         return datetime.datetime.now()

--- a/daybed/tests/test_functional.py
+++ b/daybed/tests/test_functional.py
@@ -211,6 +211,29 @@ class FunctionalTest(object):
         self.assertNotEquals('', errors[0]['name'])
 
 
+class SimpleModelTest(FunctionalTest, BaseWebTest):
+
+    model_name = 'simple'
+
+    @property
+    def valid_definition(self):
+        return {
+            "title": "simple",
+            "description": "One optional field",
+            "fields": [{"name": "age", "type": "int", "required": False}]
+        }
+
+    @property
+    def valid_data(self):
+        return {}
+
+    @property
+    def invalid_data(self):
+        return {'age': 'abc'}
+
+    def update_data(self, entry):
+        entry.pop('age', 0)
+
 
 class TodoModelTest(FunctionalTest, BaseWebTest):
 

--- a/daybed/tests/test_types.py
+++ b/daybed/tests/test_types.py
@@ -165,6 +165,24 @@ class FieldTypeTests(unittest.TestCase):
         defaulted = validator.deserialize('')
         self.assertTrue((datetime.datetime.now() - defaulted).seconds < 1)
 
+    def test_datetime_optional_auto_now(self):
+        schema = schemas.DateTimeField.definition()
+        definition = schema.deserialize(
+            {'name': 'branch',
+             'type': 'datetime',
+             'required': False})
+        validator = schemas.DateTimeField.validation(**definition)
+        self.assertEquals(colander.null, validator.deserialize(''))
+        # If auto_now, defaulted value should be now(), not null
+        definition = schema.deserialize(
+            {'name': 'branch',
+             'type': 'datetime',
+             'required': False,
+             'auto_now': True})
+        validator = schemas.DateTimeField.validation(**definition)
+        defaulted = validator.deserialize('')
+        self.assertTrue((datetime.datetime.now() - defaulted).seconds < 1)
+
     def test_point(self):
         schema = schemas.PointField.definition()
         definition = schema.deserialize(

--- a/daybed/tests/test_types.py
+++ b/daybed/tests/test_types.py
@@ -58,6 +58,22 @@ class FieldTypeTests(unittest.TestCase):
              'type': 'string'})
         self.assertEquals(definition.get('description'), '')
 
+    def test_optional_field(self):
+        schema = schemas.IntField.definition()
+        definition = schema.deserialize(
+            {'name': 'address',
+             'type': 'int'})
+        validator = schemas.IntField.validation(**definition)
+        self.assertRaises(colander.Invalid, validator.deserialize, '')
+
+        definition = schema.deserialize(
+            {'name': 'address',
+             'type': 'int',
+             'required': False})
+        validator = schemas.IntField.validation(**definition)
+        self.assertEquals(colander.null, validator.deserialize(''))
+        self.assertRaises(colander.Invalid, validator.deserialize, 'abc')
+
     def test_range(self):
         schema = schemas.RangeField.definition()
         definition = schema.deserialize(

--- a/daybed/views/fields.py
+++ b/daybed/views/fields.py
@@ -18,7 +18,7 @@ def list_fields(request):
         field = dict(name=name)
         # Describe field parameters using Colander children
         for parameter in registry.definition(name).children:
-            if parameter.name not in ['name', 'type', 'description']:
+            if parameter.name not in ['name', 'type', 'description', 'required']:
                 fieldtype = parameter.typ.__class__.__name__.lower()
                 extras = dict(name=parameter.name,
                               description=parameter.title,


### PR DESCRIPTION
Allows to specify optional fields in definition.

I opend this PR, just to make sure you're ok with the `required` keyword at field level.

```
"fields": [{"name": "age", "type": "int", "required": False}]
```

If we switch to JSON schema #53, we'll move to global `required` attributes with list of field names, at definition level.

```
"fields": [{"name": "firstname", "type": "string"}, {"name": "age", "type": "int"}],
"required": ["name"],
```

The latter is slightly more complicated in client-side form generation...
