### PR TITLE
Store deserialized data

### DIFF
--- a/daybed/backends/couchdb/database.py
+++ b/daybed/backends/couchdb/database.py
@@ -1,3 +1,4 @@
+import datetime
 from .designdocs import (
     db_model_token,
     db_definition,
@@ -48,6 +49,19 @@ class Database(object):
             return data_item
         return None
 
+    def _pre_create(self, data):
+        """Prepare data to be saved.
+
+        Main purpose here, is to convert date(time) into CouchDB format
+        """
+        ready = dict()
+        for k, v in data.items():
+            if isinstance(v, (datetime.date, datetime.datetime)):
+                ready[k] = v.isoformat()
+            else:
+                ready[k] = v
+        return ready
+
     def create_data(self, model_name, data, data_id=None):
         """Create a data to a model_name."""
         if data_id:
@@ -58,11 +72,11 @@ class Database(object):
                 'type': 'data',
                 'model_name': model_name,
             }
-        data_doc['data'] = data
+
+        data_doc['data'] = self._pre_create(data)
 
         if data_id:
             self.db[data_id] = data_doc
         else:
             data_id, rev = self.db.save(data_doc)
-
         return data_id

--- a/daybed/schemas/base.py
+++ b/daybed/schemas/base.py
@@ -117,7 +117,7 @@ class TypeFieldNode(SchemaType):
             schema = registry.definition(cstruct.get('type'))
         except UnknownFieldTypeError:
             schema = TypeField.definition()
-        schema.deserialize(cstruct)
+        return schema.deserialize(cstruct)
 
 
 class DefinitionValidator(SchemaNode):

--- a/daybed/tests/features/model_data.py
+++ b/daybed/tests/features/model_data.py
@@ -26,5 +26,5 @@ def results_are(step):
     results = world.response.json['data']
     assert len(results) >= len(step.hashes)
     for i, result in enumerate(results):
-        step.hashes[i]['id'] = result['id'] # We cannot guess it
-        assert result == step.hashes[i]
+        for k, v in step.hashes[i].items():
+            assert unicode(result[k]) == v, '%s != %s' % (repr(result[k]), repr(v))

--- a/daybed/tests/support.py
+++ b/daybed/tests/support.py
@@ -1,3 +1,4 @@
+import collections
 try:
     import unittest2 as unittest
 except ImportError:
@@ -30,3 +31,19 @@ class BaseWebTest(unittest.TestCase):
         self.app.put_json('/definitions/todo',
                           self.valid_definition,
                           headers=self.headers)
+
+
+def force_unicode(data):
+    """ Recursively force unicode.
+
+    Works for dict keys, list values etc.
+    (source: http://stackoverflow.com/questions/1254454/fastest-way-to-convert-a-dicts-keys-values-from-unicode-to-str)
+    """
+    if isinstance(data, basestring):
+        return unicode(data)
+    elif isinstance(data, collections.Mapping):
+        return dict(map(force_unicode, data.iteritems()))
+    elif isinstance(data, collections.Iterable):
+        return type(data)(map(force_unicode, data))
+    else:
+        return data

--- a/daybed/tests/test_functional.py
+++ b/daybed/tests/test_functional.py
@@ -130,9 +130,7 @@ class FunctionalTest(object):
         self.create_definition()
 
         # Put data against this definition
-        resp = self.app.post_json('/data/%s' % self.model_name,
-                                 self.valid_data,
-                                 headers=self.headers)
+        resp = self.create_data(self.valid_data)
         self.assertIn('id', resp.body)
 
     def test_invalid_data_validation(self):

--- a/daybed/tests/test_functional.py
+++ b/daybed/tests/test_functional.py
@@ -1,4 +1,4 @@
-from daybed.tests.support import BaseWebTest
+from daybed.tests.support import BaseWebTest, force_unicode
 from daybed.schemas import registry
 
 
@@ -110,7 +110,8 @@ class FunctionalTest(object):
         # Verify that the schema is the same
         resp = self.app.get('/definitions/%s' % self.model_name,
                             headers=self.headers)
-        self.assertEqual(resp.json, self.valid_definition)
+        definition = force_unicode(self.valid_definition)
+        self.assertEqual(resp.json, definition)
 
     def test_definition_deletion(self):
         resp = self.create_definition()
@@ -155,8 +156,7 @@ class FunctionalTest(object):
         resp = self.app.get('/data/%s/%s' % (self.model_name,
                                              data_item_id),
                             headers=self.headers)
-        entry = self.valid_data.copy()
-        # entry['id'] = str(data_item_id
+        entry = force_unicode(self.valid_data)
         self.assertEqual(resp.json, entry)
 
     def test_data_update(self):

--- a/daybed/tests/test_functional.py
+++ b/daybed/tests/test_functional.py
@@ -154,8 +154,10 @@ class FunctionalTest(object):
         resp = self.app.get('/data/%s/%s' % (self.model_name,
                                              data_item_id),
                             headers=self.headers)
-        entry = force_unicode(self.valid_data)
-        self.assertEqual(resp.json, entry)
+        self.assertDataCorrect(resp.json, force_unicode(self.valid_data))
+
+    def assertDataCorrect(self, data, entry):
+        self.assertEqual(data, entry)
 
     def test_data_update(self):
         self.create_definition()
@@ -291,6 +293,11 @@ class TimestampedModelTest(FunctionalTest, BaseWebTest):
         entry['creation'] = '2013-05-30'
         entry['modified'] = ''
 
+    def assertDataCorrect(self, data, entry):
+        self.assertEqual(data['creation'], entry['creation'])
+        # Check that auto-now worked
+        self.assertNotEqual(data['modified'], entry['creation'])
+
 
 class MushroomsModelTest(FunctionalTest, BaseWebTest):
 
@@ -319,7 +326,7 @@ class MushroomsModelTest(FunctionalTest, BaseWebTest):
     @property
     def valid_data(self):
         return {'mushroom': 'Boletus',
-                'location': [[[0, 0], [0, 1], [1, 1], [0, 0]]]}  # closed polygon
+                'location': [[[0, 0], [0, 1], [1, 1]]]}  # closed polygon
 
     @property
     def invalid_data(self):
@@ -328,6 +335,12 @@ class MushroomsModelTest(FunctionalTest, BaseWebTest):
 
     def update_data(self, entry):
         entry['location'] = [[[0, 0], [0, 2], [2, 2]], [[0.5, 0.5], [0.5, 1], [1, 1]]]
+
+    def assertDataCorrect(self, data, entry):
+        self.assertEqual(data['mushroom'], entry['mushroom'])
+        # Check that polygon was closed automatically
+        self.assertNotEqual(data['location'], entry['location'])
+        self.assertEqual(data['location'][0][0], data['location'][0][-1])
 
 
 class CityModelTest(FunctionalTest, BaseWebTest):

--- a/daybed/tests/test_functional.py
+++ b/daybed/tests/test_functional.py
@@ -269,7 +269,8 @@ class TimestampedModelTest(FunctionalTest, BaseWebTest):
                 {
                     "name": "creation",
                     "type": "date",
-                    "description": "created on"
+                    "description": "created on",
+                    "auto_now": False
                 },
                 {
                     "name": "modified",
@@ -311,6 +312,7 @@ class MushroomsModelTest(FunctionalTest, BaseWebTest):
                 {
                     "name": "location",
                     "type": "polygon",
+                    "gps": True,
                     "description": "Area spotted"
                 }
             ]
@@ -319,7 +321,7 @@ class MushroomsModelTest(FunctionalTest, BaseWebTest):
     @property
     def valid_data(self):
         return {'mushroom': 'Boletus',
-                'location': [[[0, 0], [0, 1], [1, 1]]]}
+                'location': [[[0, 0], [0, 1], [1, 1], [0, 0]]]}  # closed polygon
 
     @property
     def invalid_data(self):
@@ -348,6 +350,7 @@ class CityModelTest(FunctionalTest, BaseWebTest):
                 {
                     "name": "location",
                     "type": "point",
+                    "gps": True,
                     "description": "(x,y,z)"
                 }
             ]

--- a/daybed/validators.py
+++ b/daybed/validators.py
@@ -10,7 +10,7 @@ def validator(request, schema):
     try:
         body = request.body
         dictbody = json.loads(body) if body else {}
-        schema.deserialize(dictbody)
+        request.data_clean = schema.deserialize(dictbody)
     except ValueError, e:
         request.errors.add('body', 'body', str(e))
     except colander.Invalid, e:

--- a/daybed/views/data.py
+++ b/daybed/views/data.py
@@ -1,5 +1,3 @@
-import json
-
 from cornice import Service
 from pyramid.exceptions import NotFound
 
@@ -42,7 +40,7 @@ def post(request):
         return
 
     model_name = request.matchdict['model_name']
-    data_id = request.db.create_data(model_name, json.loads(request.body))
+    data_id = request.db.create_data(model_name, request.data_clean)
     created = '%s/data/%s' % (request.application_url, data_id)
     request.response.status = "201 Created"
     request.response.headers['location'] = created

--- a/daybed/views/data_item.py
+++ b/daybed/views/data_item.py
@@ -1,5 +1,3 @@
-import json
-
 from cornice import Service
 from pyramid.exceptions import NotFound
 
@@ -31,7 +29,7 @@ def put(request):
     """Update or create a data item."""
     model_name = request.matchdict['model_name']
     data_item_id = request.matchdict['data_item_id']
-    data_id = request.db.create_data(model_name, json.loads(request.body),
+    data_id = request.db.create_data(model_name, request.data_clean,
                                      data_item_id)
     return {'id': data_id}
 

--- a/daybed/views/definition.py
+++ b/daybed/views/definition.py
@@ -1,5 +1,4 @@
 import os
-import json
 
 from cornice import Service
 from pyramid.httpexceptions import HTTPNotFound
@@ -40,7 +39,7 @@ def put(request):
     model_doc = {
         'type': 'definition',
         'name': model_name,
-        'definition': json.loads(request.body),
+        'definition': request.data_clean,
         'token': token,
     }
     request.db.save(model_doc)


### PR DESCRIPTION
I wonder how it took us so long without noticing.

We weren't storing the deserialized data, but the original posted data !
This preventing clean-up and defaulting values...

Specific case has to be handled manually for storing date/times into CouchDB. Best practice seems to serialize as ISO for `Date.parse()` to work natively. (source http://stackoverflow.com/a/4773320)

I propose this into master, since it is bug :) 

@natim, this may break daybed-pass since you are storing JSON as string. Luckyly, I had this check for a while in daybed-map https://github.com/leplatrem/daybed-map/blob/dev/models.js#L20-L22

This fixes #67 
