### PR TITLE
Create the venv before using the Makefile and make it use the current venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,20 @@
-VIRTUALENV=virtualenv
-VENV=.
-PYTHON=$(VENV)/bin/python
 DEV_STAMP=.dev_env_installed.stamp
 INSTALL_STAMP=.install.stamp
 
-.IGNORE: clean
-.PHONY: all install virtualenv tests
+.PHONY: all install virtualenv tests clean
 
-OBJECTS = bin/ lib/ local/ include/ man/ .coverage d2to1-0.2.7-py2.7.egg \
-	.coverage daybed.egg-info
+OBJECTS = .coverage daybed.egg-info
 
 all: install
 install: $(INSTALL_STAMP)
-$(INSTALL_STAMP): $(PYTHON)
-	$(PYTHON) setup.py develop
+$(INSTALL_STAMP):
+	python setup.py develop
 	touch $(INSTALL_STAMP)
 
 install-dev: $(DEV_STAMP)
-$(DEV_STAMP): $(PYTHON)
-	$(VENV)/bin/pip install -r dev-requirements.txt
+$(DEV_STAMP):
+	pip install -r dev-requirements.txt
 	touch $(DEV_STAMP)
-
-virtualenv: $(PYTHON)
-$(PYTHON):
-	$(VIRTUALENV) $(VENV)
 
 clean:
 	rm -fr $(OBJECTS) $(DEV_STAMP) $(INSTALL_STAMP)
@@ -31,10 +22,10 @@ clean:
 	find . -name '__pycache__' -delete
 
 tests: install-dev
-	bin/tox
+	tox
 
-tests-failfast: .tox/py27/
-	.tox/py27/bin/nosetests --with-coverage --cover-package=daybed -x -s
+tests-failfast:
+	nosetests --with-coverage --cover-package=daybed -x -s
 
 serve: install install-dev
-	$(VENV)/bin/pserve development.ini --reload
+	pserve development.ini --reload

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,7 +31,7 @@ Hacking daybed
 --------------
 
 Daybed comes with a Makefile to simplify your life when developing. To install
-your virtual environment and get started, you need to type::
+daybed in your current virtualenv and get started, you need to type::
 
     make install
 


### PR DESCRIPTION
So we can choose with which version of python we want to play.
