### PR TITLE
Document ACL and roles/groups

### DIFF
--- a/daybed/acl.py
+++ b/daybed/acl.py
@@ -21,12 +21,12 @@ C_UD = {'create': True,
 
 PERMISSION_FULL = {'definition': CRUD,
                    'records': CRUD,
-                   'users': CRUD,
+                   'roles': CRUD,
                    'policy': CRUD}
-PERMISSION_CREATE = {'definition': {'create': True},
-                     'records': {'create': True},
-                     'users': {'create': True},
-                     'policy': {'create': True}}
+PERMISSION_CREATE = {'definition': {'read': True},
+                     'records': C_UD,
+                     'roles': {'read': True},
+                     'policy':  {'read': True}}
 
 POLICY_READONLY = {'role:admins': PERMISSION_FULL,
                    Authenticated: PERMISSION_CREATE,
@@ -44,15 +44,15 @@ VIEWS_PERMISSIONS_REQUIRED = {
     'post_model': PERMISSION_CREATE,
     'get_model':  {'definition': {'read': True},
                    'records':    {'read': True},
-                   'users':      {'read': True},
+                   'roles':      {'read': True},
                    'policy':     {'read': True}},
     'put_model':  {'definition': C_UD,
                    'records':    C_UD,
-                   'users':      C_UD,
+                   'roles':      C_UD,
                    'policy':     C_UD},
     'delete_model': {'definition': {'delete': True},
                      'records':    {'delete': True},
-                     'users':      {'delete': True},
+                     'roles':      {'delete': True},
                      'policy':     {'delete': True}},
 
     'get_definition': {'definition': {'read': True}},
@@ -65,7 +65,7 @@ VIEWS_PERMISSIONS_REQUIRED = {
     'put_record': {'records': C_UD},
     'patch_record': {'records': {'update': True}},
     'delete_record': {'records': {'delete': True}}
-    # XXX Add users / policy management.
+    # XXX Add roles / policy management.
 }
 
 
@@ -111,7 +111,7 @@ def get_binary_mask(permission):
     possible to do boolean operations with it.
 
     A binary mask has four blocks of 4 bits, i.e one CRUD mask for each domain.
-    Domains are definition, records, users and policy, from left to right.
+    Domains are definition, records, roles and policy, from left to right.
 
     A CRUD mask range goes from 0 (no permission) to 15 (C+R+U+D).
     """
@@ -128,7 +128,7 @@ def get_binary_mask(permission):
         return byte
 
     result = 0x0
-    for i, name in enumerate(['policy', 'users', 'records', 'definition']):
+    for i, name in enumerate(['policy', 'roles', 'records', 'definition']):
         shift = 4 * i
         mask = singlemask(permission.get(name, {}))
         result |= (mask << shift)

--- a/daybed/backends/couchdb/database.py
+++ b/daybed/backends/couchdb/database.py
@@ -144,7 +144,7 @@ class Database(object):
         For instance::
 
             {'admins': ['group:pirates', 'group:flibustiers'],
-             'users': ['Remy', 'Alexis']}
+             'moderators': ['Remy', 'Alexis']}
         """
         doc = self.__get_model(model_id)
         return doc['roles']

--- a/daybed/schemas/validators.py
+++ b/daybed/schemas/validators.py
@@ -53,7 +53,7 @@ class PolicyValidator(SchemaNode):
                      if key not in ('title', 'description')]
             for key in roles:
                 permSchema = SchemaNode(Mapping(unknown='raise'), name=key)
-                for domain in ('definition', 'records', 'users', 'policy'):
+                for domain in ('definition', 'records', 'roles', 'policy'):
                     permSchema.add(self._crudSchema(domain))
                 self.add(permSchema)
         return super(PolicyValidator, self).deserialize(cstruct)

--- a/docs/source/acl.rst
+++ b/docs/source/acl.rst
@@ -10,7 +10,8 @@ a policy:
 
 - "All the users have the right to push new content to this model"
 - "Alexis is able to delete content from others"
-- "The users in the group 'rangers' have the right to create new records".
+- "Users of the group 'rangers' have the right to create new records".
+
 
 Roles
 =====
@@ -21,8 +22,8 @@ policy.
 *Roles* are defined by the model itself, but some default ones already exist:
 
 - admins
-- users
 - authors
+
 
 Users and groups
 ================
@@ -30,12 +31,152 @@ Users and groups
 Each user can be associated to a number of groups. Groups start by `group:` in
 the daybed storage layer.
 
-Rights
-======
+When you give a role to a group, all users inside the group have the role.
+
+This can be really useful if a set of users share records or models
+because you can add some of them by just adding them to a group
+instead of adding them to the role of each records or models.
+
+Let say, John and Mike manage the daybed server. They are in the owner
+group. 
+
+Later Mike leave the company and Dan arrive.
+
+Because every model and records are own by the owner group John can
+just remove Mike and add Dan inside the owner group to fix all the roles.
+
+
+Policy and Rights
+=================
+
+The policy define rights for each roles of a model.
 
 Rights are defined for:
 
-- the definition
-- the users
-- the policy
-- the data
+- Definition
+- Roles
+- Policy
+- Data
+
+For example the read-only policy could be defined as this:
+
+    Everybody can read anything but only Authenticated users can add
+    new records and authors can update their records
+
+In Daybed this will be something like:
+
+.. code-block:: json
+
+    {
+        "role:admins": {"definition": {"create": true, "read": true,
+                                       "update": true, "delete": true},
+                        "records":    {"create": true, "read": true,
+                                       "update": true, "delete": true},
+                        "roles":      {"create": true, "read": true,
+                                       "update": true, "delete": true},
+                        "policy":     {"create": true, "read": true,
+                                       "update": true, "delete": true}},
+        "authors:": {"records": {"create": true, "read": true,
+                                 "update": true, "delete": true}},
+        "system.Authenticated": {"records":    {"create": true}
+                                 "roles":      {"read": true},
+                                 "policy":     {"read": true}},
+        "system.Everyone": {"definition": {"read": true},
+                            "records":    {"read": true}},
+    }
+
+When a user try an action, a list of principals is generated based on
+the policy and the role the user has inside it.
+
+Full example
+============
+
+Let say the user John try to edit the following record:
+
+.. code-block:: json
+
+    {
+        'type': 'data',
+        'authors': ['john'],
+        'model_id': 'todo',
+        'data': {"item": "finish the documentation", "status": "todo"}
+    }
+
+Of the following model:
+
+.. code-block::
+
+    {
+        "type": "definition",
+        "_id": "todo",
+        "definition": {
+          "title": "todo",
+          "description": "A list of my stuff to do",
+          "fields": [
+              {
+                  "name": "item",
+                  "type": "string",
+                  "label": "The item"
+              },
+              {
+                  "name": "status",
+                  "type": "enum",
+                  "choices": [
+                      "done",
+                      "todo"
+                  ],
+                  "label": "is it done or not"
+              }
+           ]
+        },
+        "roles": {
+		  "admins": ["group:admins", "Mike"]
+        },
+        "policy_id": "read-only"
+    }
+
+If `john` tries to modify this record, he will have the following principals::
+
+    ["system.Authenticated", "system.Everyone", "authors:"]
+
+And the right set for all this principals will be accredited to him:
+
+.. code-block:: json
+
+    {
+      "definition": {"read": true},
+      "records":    {"create": true, "read": true,
+                     "update": true, "delete": true},
+      "roles":      {"read": true},
+      "policy":     {"read": true}
+    }
+
+So John will be able to modify its record.
+
+If Dan want to modify the same records he will get::
+
+    ["system.Authenticated", "system.Everyone"]
+
+.. code-block:: json
+
+    {
+      "definition": {"read": true},
+      "records":    {"create": true, "read": true},
+      "roles":      {"read": true},
+      "policy":     {"read": true}
+    }
+
+He will not have the right to modify it.
+
+Alexis is in the `admins` group, if he tries to modify the record, he
+will get the `role:admins` and get full access::
+
+    ["system.Authenticated", "system.Everyone", "role:admins"]
+
+Alexis will be able to modify it.
+
+If Mike tries to modify it, because he has the `role:admins` he will get full access::
+
+    ["system.Authenticated", "system.Everyone", "role:admins"]
+
+Mike will be able to modify it.


### PR DESCRIPTION
The conceptual difference between a role and a group is hard to grasp; We should make it clear in the documentation, by showcasing real use cases.
