### PR TITLE
Get rid of underscores in API

### DIFF
--- a/daybed/schemas/base.py
+++ b/daybed/schemas/base.py
@@ -171,21 +171,21 @@ class URLField(TypeField):
 
 
 class AutoNowMixin(object):
-    """Mixin to share ``auto_now`` mechanism for both date and datetime fields.
+    """Mixin to share ``autonow`` mechanism for both date and datetime fields.
     """
-    auto_now = False
+    autonow = False
 
     @classmethod
     def definition(cls):
         schema = super(AutoNowMixin, cls).definition()
-        schema.add(SchemaNode(Boolean(), name='auto_now',
-                              missing=cls.auto_now))
+        schema.add(SchemaNode(Boolean(), name='autonow',
+                              missing=cls.autonow))
         return schema
 
     @classmethod
     def validation(cls, **kwargs):
-        auto_now = kwargs.get('auto_now', cls.auto_now)
-        if auto_now:
+        autonow = kwargs.get('autonow', cls.autonow)
+        if autonow:
             kwargs['missing'] = cls.auto_value
         return super(AutoNowMixin, cls).validation(**kwargs).bind()
 

--- a/daybed/schemas/validators.py
+++ b/daybed/schemas/validators.py
@@ -164,12 +164,12 @@ def model_validator(request):
     validate_against_schema(request, RolesSchema(), roles)
 
     request.validated['roles'] = roles
-    policy_id = body.get('policy_id', request.registry.default_policy)
+    policy_id = body.get('policy', request.registry.default_policy)
 
     # Check that the policy exists in our db.
     try:
         request.db.get_policy(policy_id)
     except PolicyNotFound:
-        request.errors.add('body', 'policy_id',
+        request.errors.add('body', 'policy',
                            "policy '%s' doesn't exist" % policy_id)
-    request.validated['policy_id'] = policy_id
+    request.validated['policy'] = policy_id

--- a/daybed/tests/test_functional.py
+++ b/daybed/tests/test_functional.py
@@ -363,14 +363,14 @@ class TimestampedModelTest(FunctionalTest, BaseWebTest):
                     "type": "date",
                     "label": "created on",
                     "required": True,
-                    "auto_now": False
+                    "autonow": False
                 },
                 {
                     "name": "modified",
                     "type": "datetime",
                     "label": "modified on",
                     "required": True,
-                    "auto_now": True
+                    "autonow": True
                 },
             ]
         }

--- a/daybed/tests/test_functional.py
+++ b/daybed/tests/test_functional.py
@@ -54,7 +54,7 @@ class FunctionalTest(object):
     def test_post_model_definition_wrong_policy(self):
         self.app.post_json('/models',
                            {'definition': self.valid_definition,
-                            'policy_id': 'unknown'},
+                            'policy': 'unknown'},
                            headers=self.headers,
                            status=400)
 

--- a/daybed/tests/test_schemas_base.py
+++ b/daybed/tests/test_schemas_base.py
@@ -238,7 +238,7 @@ class DateFieldTests(unittest.TestCase):
         definition = schema.deserialize(
             {'name': 'birth',
              'type': 'date',
-             'auto_now': True})
+             'autonow': True})
         validator = schemas.DateField.validation(**definition)
         defaulted = validator.deserialize(None)
         self.assertEqual(datetime.date.today(), defaulted)
@@ -270,19 +270,19 @@ class DateFieldTests(unittest.TestCase):
         self.assertRaises(colander.Invalid, validator.deserialize,
                           '2012-04-30T13:60Z')
 
-    def test_datetime_auto_now(self):
+    def test_datetime_autonow(self):
         schema = schemas.DateTimeField.definition()
         definition = schema.deserialize(
             {'name': 'branch',
              'type': 'datetime',
-             'auto_now': True})
+             'autonow': True})
         validator = schemas.DateTimeField.validation(**definition)
         defaulted = validator.deserialize(None)
         self.assertTrue((datetime.datetime.now() - defaulted).seconds < 1)
         defaulted = validator.deserialize('')
         self.assertTrue((datetime.datetime.now() - defaulted).seconds < 1)
 
-    def test_datetime_optional_auto_now(self):
+    def test_datetime_optional_autonow(self):
         schema = schemas.DateTimeField.definition()
         definition = schema.deserialize(
             {'name': 'branch',
@@ -290,12 +290,12 @@ class DateFieldTests(unittest.TestCase):
              'required': False})
         validator = schemas.DateTimeField.validation(**definition)
         self.assertEquals(colander.null, validator.deserialize(''))
-        # If auto_now, defaulted value should be now(), not null
+        # If autonow, defaulted value should be now(), not null
         definition = schema.deserialize(
             {'name': 'branch',
              'type': 'datetime',
              'required': False,
-             'auto_now': True})
+             'autonow': True})
         validator = schemas.DateTimeField.validation(**definition)
         defaulted = validator.deserialize('')
         self.assertTrue((datetime.datetime.now() - defaulted).seconds < 1)

--- a/daybed/tests/test_schemas_object.py
+++ b/daybed/tests/test_schemas_object.py
@@ -18,7 +18,7 @@ OBJECT_FIELD_DEFINITION = {
          'label': u'',
          'hint': u'True or false',
          'required': True},
-        {'auto_now': False,
+        {'autonow': False,
          'type': u'datetime',
          'name': u'updated',
          'label': u'',

--- a/daybed/tests/test_views.py
+++ b/daybed/tests/test_views.py
@@ -123,7 +123,7 @@ class PolicyTest(BaseWebTest):
                                 "fields": [{"name": "age", "type": "int",
                                             "required": False}]
                                 },
-                 'policy_id': policy_id}
+                 'policy': policy_id}
 
         self.app.put_json('/models/test', model,
                           headers=self.headers, status=200)

--- a/daybed/views/models.py
+++ b/daybed/views/models.py
@@ -40,7 +40,7 @@ def post_models(request):
     model_id = request.db.put_model(
         definition=request.validated['definition'],
         roles=request.validated['roles'],
-        policy_id=request.validated['policy_id'])
+        policy_id=request.validated['policy'])
 
     if request.user:
         username = request.user['name']
@@ -80,7 +80,7 @@ def get_model(request):
 
     return {'definition': definition,
             'records': request.db.get_records(model_id),
-            'policy_id': request.db.get_model_policy_id(model_id),
+            'policy': request.db.get_model_policy_id(model_id),
             'roles': request.db.get_roles(model_id)}
 
 
@@ -101,7 +101,7 @@ def put_model(request):
 
     request.db.put_model(request.validated['definition'],
                          request.validated['roles'],
-                         request.validated['policy_id'],
+                         request.validated['policy'],
                          model_id)
 
     for record in request.validated['records']:

--- a/docs/source/acl.rst
+++ b/docs/source/acl.rst
@@ -130,9 +130,9 @@ Of the following model:
            ]
         },
         "roles": {
-		  "admins": ["group:admins", "Mike"]
+            "admins": ["group:admins", "Mike"]
         },
-        "policy_id": "read-only"
+        "policy": "read-only"
     }
 
 If `john` tries to modify this record, he will have the following principals::

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -85,7 +85,7 @@ We can now get our models back::
         "roles": {
             "admins": ["admin@example.com"]
         },
-        "policy_id": "read-only"
+        "policy": "read-only"
     }
 
 **POST /models**


### PR DESCRIPTION
Outside the Python, underscores are ugly.
