### PR TITLE
Fix group field validation

### DIFF
--- a/daybed/schemas/__init__.py
+++ b/daybed/schemas/__init__.py
@@ -79,7 +79,7 @@ class TypeField(object):
     hint = u''
 
     @classmethod
-    def definition(cls):
+    def definition(cls, **kwargs):
         schema = SchemaNode(Mapping())
         schema.add(SchemaNode(String(), name='name',
                               validator=Regex(r'^[a-zA-Z][a-zA-Z0-9_\-]*$')))
@@ -104,10 +104,11 @@ class TypeField(object):
 
 class TypeFieldNode(SchemaType):
     def deserialize(self, node, cstruct=null):
+        kwargs = dict(node=node, cstruct=cstruct)
         try:
-            schema = registry.definition(cstruct.get('type'))
+            schema = registry.definition(cstruct.get('type'), **kwargs)
         except UnknownFieldTypeError:
-            schema = TypeField.definition()
+            schema = TypeField.definition(**kwargs)
         return schema.deserialize(cstruct)
 
 

--- a/daybed/schemas/base.py
+++ b/daybed/schemas/base.py
@@ -67,7 +67,7 @@ class EnumField(TypeField):
     hint = _('A choice among values')
 
     @classmethod
-    def definition(cls):
+    def definition(cls, **kwargs):
         schema = super(EnumField, cls).definition()
         schema.add(SchemaNode(Sequence(), SchemaNode(String()),
                               name='choices', validator=Length(min=1)))
@@ -85,7 +85,7 @@ class ChoicesField(TypeField):
     hint = _('Some choices among values')
 
     @classmethod
-    def definition(cls):
+    def definition(cls, **kwargs):
         schema = super(ChoicesField, cls).definition()
         schema.add(SchemaNode(Sequence(), SchemaNode(String()),
                               name='choices', validator=Length(min=1)))
@@ -103,7 +103,7 @@ class RangeField(TypeField):
     hint = _('A number with limits')
 
     @classmethod
-    def definition(cls):
+    def definition(cls, **kwargs):
         schema = super(RangeField, cls).definition()
         schema.add(SchemaNode(Int(), name='min'))
         schema.add(SchemaNode(Int(), name='max'))
@@ -123,7 +123,7 @@ class RegexField(TypeField):
     hint = _('A string matching a pattern')
 
     @classmethod
-    def definition(cls):
+    def definition(cls, **kwargs):
         schema = super(RegexField, cls).definition()
         schema.add(SchemaNode(String(), name='regex', validator=Length(min=1)))
         return schema
@@ -176,7 +176,7 @@ class AutoNowMixin(object):
     autonow = False
 
     @classmethod
-    def definition(cls):
+    def definition(cls, **kwargs):
         schema = super(AutoNowMixin, cls).definition()
         schema.add(SchemaNode(Boolean(), name='autonow',
                               missing=cls.autonow))

--- a/daybed/schemas/base.py
+++ b/daybed/schemas/base.py
@@ -21,7 +21,7 @@ from colander import (
     drop
 )
 
-from . import registry, TypeField
+from . import registry, TypeField, TypeFieldNode
 from .json import JSONList
 
 
@@ -220,6 +220,6 @@ class GroupField(TypeField):
         schema.children = [c for c in schema.children
                            if c.name not in ('hint', 'name', 'required')]
         schema.add(SchemaNode(String(), name='description', missing=drop))
-        schema.add(SchemaNode(Sequence(), TypeField.definition(),
+        schema.add(SchemaNode(Sequence(), SchemaNode(TypeFieldNode()),
                               name='fields', validator=Length(min=1)))
         return schema

--- a/daybed/schemas/geom.py
+++ b/daybed/schemas/geom.py
@@ -105,7 +105,7 @@ class GeometryField(TypeField):
     subnode = PointNode
 
     @classmethod
-    def definition(cls):
+    def definition(cls, **kwargs):
         schema = super(GeometryField, cls).definition()
         schema.add(SchemaNode(Boolean(), name='gps', missing=cls.gps))
         return schema

--- a/daybed/schemas/object.py
+++ b/daybed/schemas/object.py
@@ -6,20 +6,9 @@ from colander import (Sequence, SchemaNode, Length, String, drop, Invalid)
 from daybed.backends.exceptions import ModelNotFound
 
 from . import registry, TypeField, TypeFieldNode, get_db
-from .validators import RecordSchema
+from .validators import RecordValidator
 from .relations import ModelExist
 from .json import JSONType
-
-
-class ObjectMatchDefinition(object):
-    """A validator to check that a dictionnary matches the specified
-    definition.
-    """
-    def __init__(self, definition):
-        self.schema = RecordSchema(definition)
-
-    def __call__(self, node, value):
-        self.schema.deserialize(value)
 
 
 class ExclusiveKeys(object):
@@ -66,7 +55,7 @@ class ObjectField(TypeField):
     @classmethod
     def validation(cls, **kwargs):
         definition = cls._fetch_definition(kwargs)
-        kwargs['validator'] = ObjectMatchDefinition(definition)
+        kwargs['validator'] = RecordValidator(definition)
         return super(ObjectField, cls).validation(**kwargs)
 
     @classmethod

--- a/daybed/schemas/validators.py
+++ b/daybed/schemas/validators.py
@@ -30,6 +30,7 @@ class RecordSchema(SchemaNode):
         super(RecordSchema, self).__init__(Mapping())
         definition = deepcopy(definition)
         for field in definition['fields']:
+            field['root'] = self
             fieldtype = field.pop('type')
             self.add(registry.validation(fieldtype, **field))
 

--- a/daybed/schemas/validators.py
+++ b/daybed/schemas/validators.py
@@ -34,6 +34,17 @@ class RecordSchema(SchemaNode):
             self.add(registry.validation(fieldtype, **field))
 
 
+class RecordValidator(object):
+    """A validator to check that a dictionnary matches the specified
+    definition.
+    """
+    def __init__(self, definition):
+        self.schema = RecordSchema(definition)
+
+    def __call__(self, node, value):
+        self.schema.deserialize(value)
+
+
 def validate_against_schema(request, schema, data, field_name=None):
     try:
         data_pure = schema.deserialize(data)

--- a/daybed/tests/test_schemas.py
+++ b/daybed/tests/test_schemas.py
@@ -47,7 +47,7 @@ class TypeFieldNodeTests(unittest.TestCase):
     def setUp(self):
         class FooField(TypeField):
             @classmethod
-            def definition(self):
+            def definition(self, **kwargs):
                 mocked = mock.Mock()
                 mocked.deserialize.return_value = 'blah'
                 return mocked

--- a/daybed/tests/test_schemas_base.py
+++ b/daybed/tests/test_schemas_base.py
@@ -183,7 +183,7 @@ class GroupFieldTests(unittest.TestCase):
             'type': u'group',
             'fields': [{'type': u'int',
                         'name': u'a',
-                        'hint': u'',
+                        'hint': u'An integer',
                         'label': u'',
                         'required': True}]}
 
@@ -209,6 +209,12 @@ class GroupFieldTests(unittest.TestCase):
     def test_a_group_must_have_valid_fields(self):
         definition = self.definition.copy()
         definition['fields'].append({'type': u'int'})
+        self.assertRaises(colander.Invalid, self.schema.deserialize,
+                          definition)
+
+    def test_a_group_must_have_valid_fields_parameters(self):
+        definition = self.definition.copy()
+        definition['fields'][0]['type'] = u'regex'
         self.assertRaises(colander.Invalid, self.schema.deserialize,
                           definition)
 

--- a/daybed/tests/test_schemas_base.py
+++ b/daybed/tests/test_schemas_base.py
@@ -186,6 +186,13 @@ class GroupFieldTests(unittest.TestCase):
                         'hint': u'An integer',
                         'label': u'',
                         'required': True}]}
+        modeldefinition = {
+            'fields': [{'type': u'string',
+                        'name': 'b'},
+                       self.definition]
+        }
+        from daybed.schemas.validators import RecordSchema
+        self.validator = RecordSchema(modeldefinition)
 
     def test_a_group_has_no_name_nor_hint(self):
         definition = self.definition.copy()
@@ -217,6 +224,15 @@ class GroupFieldTests(unittest.TestCase):
         definition['fields'][0]['type'] = u'regex'
         self.assertRaises(colander.Invalid, self.schema.deserialize,
                           definition)
+
+    def test_a_group_validation_succeeds_if_records_are_valid(self):
+        value = self.validator.deserialize({"a": 1, "b": "good"})
+        self.assertEquals(value, {'a': 1, 'b': u'good'})
+
+    def test_a_group_validation_fails_if_records_are_invalid(self):
+        self.assertRaises(colander.Invalid,
+                          self.validator.deserialize,
+                          {"a": "booh", "b": "good"})
 
 
 class DateFieldTests(unittest.TestCase):


### PR DESCRIPTION
~~I'm stuck with group fields, and I'm currently thinking of getting rid of them.~~

My first idea was just to allow grouping of fields, in a way that does not affect their individual validation at all.

For example, the following model : 

``` javascript
{name: 'person',
 fields: [
    {name: 'age', type: 'int'},
    {description: 'address',
     type: 'group',
     fields: [{name: 'street', type: 'string'},
              {name: 'city', type: 'string'}]
    }
 ]
}
```

could validate this record

``` javascript
{age: 12, street: 'bakery', city: 'london'}
```

I must admit that the group field type I had in mind belongs more to the presentation layer (grouping widgets in forms) than the model layer.

The current implementation is completely wrong : it does not validate at all ! (see #189, #192)

I tried to hack around, ~~but I cannot find~~ I found a way to flatten the fields list (i.e. expending the fields at the model level with the ones from the group fields).

~~And if we validate in a dict (e.g. `{age: 12, '': {street: 'bakery', city: 'london'}}`), then there is no difference with the `object` field, which is well tested and rather intuitive...~~

~~Any idea ? Opposition to `group` field type removal ?~~
