### PR TITLE
[WIP] Add Json schema support

### DIFF
--- a/daybed/__init__.py
+++ b/daybed/__init__.py
@@ -24,7 +24,7 @@ from daybed.acl import (
     RootFactory, DaybedAuthorizationPolicy, check_api_token,
 )
 from daybed.views.errors import forbidden_view
-from daybed.renderers import GeoJSON
+from daybed.renderers import GeoJSON, JSONSchema
 from daybed.backends.exceptions import TokenNotFound
 
 
@@ -108,6 +108,7 @@ def main(global_config, **settings):
     config.add_subscriber(add_default_accept, NewRequest)
 
     config.add_renderer('jsonp', JSONP(param_name='callback'))
-
     config.add_renderer('geojson', GeoJSON())
+    config.add_renderer('jsonschema', JSONSchema())
+
     return config.make_wsgi_app()

--- a/daybed/renderers.py
+++ b/daybed/renderers.py
@@ -21,6 +21,7 @@ class JSONSchema(JSONP):
             'url': lambda x: {'type': 'string', 'format': 'uri'},
             'enum': self.serialize_enum,
             'range': self.serialize_range,
+            'datetime': self.serialize_datetime,
         }
         super(JSONSchema, self).__init__(*args, **kwargs)
 
@@ -72,6 +73,13 @@ class JSONSchema(JSONP):
             'type': 'integer',
             'minimum': field['min'],
             'maximum': field['max']
+        }
+
+    def serialize_datetime(self, field):
+        return {
+            'type': 'string',
+            'pattern': '(\d{4})-(\d{2})-(\d{2})T(\d{2})\:(\d{2})\:(\d{2})'
+                       '[+-](\d{2})\:(\d{2})'
         }
 
 

--- a/daybed/tests/test_renderers.py
+++ b/daybed/tests/test_renderers.py
@@ -67,13 +67,21 @@ class TestJSONSchemaRenderer(BaseRendererTest):
     def test_regex_type(self):
         self.assertEquals(
             self._get_rendered_field('regex', regex='^[abc]$'),
-            {'type': 'string', 'pattern': '^[abc]$'}
+            {
+                'description': 'field',
+                'type': 'string',
+                'pattern': '^[abc]$'
+            }
         )
 
     def test_email_type(self):
         self.assertEquals(
             self._get_rendered_field('email'),
-            {'type': 'string', 'format': 'email'}
+            {
+                'description': 'field',
+                'type': 'string',
+                'format': 'email'
+            }
         )
 
     def test_anyof_type(self):
@@ -85,7 +93,11 @@ class TestJSONSchemaRenderer(BaseRendererTest):
     def test_url(self):
         self.assertEquals(
             self._get_rendered_field('url'),
-            {'type': 'string', 'format': 'uri'}
+            {
+                'description': 'field',
+                'type': 'string',
+                'format': 'uri'
+            }
         )
 
     def test_decimal(self):
@@ -97,7 +109,11 @@ class TestJSONSchemaRenderer(BaseRendererTest):
     def test_enum_type(self):
         self.assertEquals(
             self._get_rendered_field('enum', choices=('foo', 'bar')),
-            {'type': 'string', 'pattern': '^foo|bar$'}
+            {
+                'description': 'field',
+                'type': 'string',
+                'pattern': '^foo|bar$'
+            }
         )
 
     def test_list(self):
@@ -109,7 +125,12 @@ class TestJSONSchemaRenderer(BaseRendererTest):
     def test_range(self):
         self.assertEquals(
             self._get_rendered_field('range', min=1, max=10),
-            {'type': 'integer', 'minimum': 1, 'maximum': 10}
+            {
+                'description': 'field',
+                'type': 'integer',
+                'minimum': 1,
+                'maximum': 10
+            }
         )
 
 

--- a/daybed/tests/test_renderers.py
+++ b/daybed/tests/test_renderers.py
@@ -3,11 +3,117 @@ import json
 import mock
 from pyramid import testing
 
-from daybed.renderers import GeoJSON
+from daybed.renderers import GeoJSON, JSONSchema
 from .support import BaseWebTest, force_unicode
 
 
-class TestGeoJSONRenderer(BaseWebTest):
+class BaseRendererTest(BaseWebTest):
+    def _build_request(self, name=None):
+        request = testing.DummyRequest()
+        if name is not None:
+            request.matchdict['model_id'] = name
+        request.db = self.db
+        return request
+
+    def _rendered(self, data, request=None):
+        request = request or self._build_request()
+        system = {'request': request}
+        return self.renderer(data, system)
+
+
+class TestJSONSchemaRenderer(BaseRendererTest):
+
+    def setUp(self):
+        super(TestJSONSchemaRenderer, self).setUp()
+        self.jsonschema = JSONSchema()
+        self.renderer = self.jsonschema(None)
+
+    def _get_definition(self, type, **args):
+        field = {
+            "name": "field",
+            "type": type,
+            "required": False
+        }
+        field.update(args)
+        return {
+            "title": "simple",
+            "description": "One field",
+            "fields": [field]
+        }
+
+    def _get_rendered_field(self, type, **args):
+        return json.loads(
+            self._rendered(self._get_definition(type, **args))
+        )['properties']['field']
+
+    def test_int_type(self):
+        self.assertEquals(
+            self._get_rendered_field('int')['type'],
+            'integer'
+        )
+
+    def test_test_type(self):
+        self.assertEquals(
+            self._get_rendered_field('text')['type'],
+            'string'
+        )
+
+    def test_bool_type(self):
+        self.assertEquals(
+            self._get_rendered_field('boolean')['type'],
+            'boolean'
+        )
+
+    def test_regex_type(self):
+        self.assertEquals(
+            self._get_rendered_field('regex', regex='^[abc]$'),
+            {'type': 'string', 'pattern': '^[abc]$'}
+        )
+
+    def test_email_type(self):
+        self.assertEquals(
+            self._get_rendered_field('email'),
+            {'type': 'string', 'format': 'email'}
+        )
+
+    def test_anyof_type(self):
+        pass
+
+    def test_oneof_type(self):
+        pass
+
+    def test_url(self):
+        self.assertEquals(
+            self._get_rendered_field('url'),
+            {'type': 'string', 'format': 'uri'}
+        )
+
+    def test_decimal(self):
+        self.assertEquals(
+            self._get_rendered_field('decimal')['type'],
+            'number'
+        )
+
+    def test_enum_type(self):
+        self.assertEquals(
+            self._get_rendered_field('enum', choices=('foo', 'bar')),
+            {'type': 'string', 'pattern': '^foo|bar$'}
+        )
+
+    def test_list(self):
+        pass
+
+    def test_choices(self):
+        pass
+
+    def test_range(self):
+        self.assertEquals(
+            self._get_rendered_field('range', min=1, max=10),
+            {'type': 'integer', 'minimum': 1, 'maximum': 10}
+        )
+
+
+class TestGeoJSONRenderer(BaseRendererTest):
 
     def setUp(self):
         super(TestGeoJSONRenderer, self).setUp()
@@ -39,17 +145,6 @@ class TestGeoJSONRenderer(BaseWebTest):
 
     def assertJSONEqual(self, a, b):
         self.assertDictEqual(json.loads(a), force_unicode(b))
-
-    def _build_request(self, name=None):
-        request = testing.DummyRequest()
-        request.matchdict['model_id'] = name or self.name
-        request.db = self.db
-        return request
-
-    def _rendered(self, data, request=None):
-        request = request or self._build_request()
-        system = {'request': request}
-        return self.renderer(data, system)
 
     def test_geojson_renderer_with_empty_collection(self):
         geojson = self._rendered({'records': []})
@@ -87,7 +182,7 @@ class TestGeoJSONRenderer(BaseWebTest):
                               'coordinates': [[0, 0], [1, 1]]})
 
     def test_geojson_renderer_works_with_jsonp(self):
-        request = self._build_request()
+        request = self._build_request(name=self.name)
         request.GET['callback'] = 'func'
         geojsonp = self._rendered({'records': [{'location': [0, 0]}]}, request)
         self.assertIn('func(', geojsonp)
@@ -107,7 +202,7 @@ class TestGeoJSONRenderer(BaseWebTest):
             ]})
 
     def test_geojson_renderer_serves_with_official_mimetype(self):
-        request = self._build_request()
+        request = self._build_request(name=self.name)
         response = mock.MagicMock()
         response.default_content_type = response.content_type = ''
         request.response = response
@@ -116,7 +211,7 @@ class TestGeoJSONRenderer(BaseWebTest):
                          'application/vnd.geo+json')
 
     def test_geojson_renderer_does_not_override_existing_mimetype(self):
-        request = self._build_request()
+        request = self._build_request(name=self.name)
         response = mock.MagicMock()
         response.content_type = 'application/octet-stream'
         request.response = response

--- a/daybed/tests/test_renderers.py
+++ b/daybed/tests/test_renderers.py
@@ -84,6 +84,17 @@ class TestJSONSchemaRenderer(BaseRendererTest):
             }
         )
 
+    def test_datetime_type(self):
+        self.assertEquals(
+            self._get_rendered_field('datetime'),
+            {
+                'description': 'field',
+                'type': 'string',
+                'pattern': '(\d{4})-(\d{2})-(\d{2})T(\d{2})\:(\d{2})\:(\d{2})'
+                           '[+-](\d{2})\:(\d{2})'
+            }
+        )
+
     def test_anyof_type(self):
         pass
 

--- a/daybed/tests/test_views.py
+++ b/daybed/tests/test_views.py
@@ -370,6 +370,30 @@ class ModelsViewsTest(BaseWebTest):
         definition = force_unicode(MODEL_DEFINITION['definition'])
         self.assertDictEqual(resp.json, definition)
 
+    def test_definition_retrieval_as_json_schema(self):
+        self.app.put_json('/models/test',
+                          MODEL_DEFINITION,
+                          headers=self.headers)
+
+        self.headers['Accept'] = 'application/schema+json'
+
+        resp = self.app.get('/models/test/definition',
+                            headers=self.headers)
+
+        self.assertDictEqual(resp.json, {
+            '$schema': 'http://json-schema.org/schema#',
+            'title': 'simple',
+            'description': u'One optional field',
+            'type': 'object',
+            'properties': {
+                'age': {
+                    'description': 'age',
+                    'type': 'integer',
+                }
+            },
+            'required': []
+        })
+
     def test_post_model_definition_with_records(self):
         model = MODEL_DEFINITION.copy()
         model['records'] = [MODEL_RECORD, MODEL_RECORD]

--- a/daybed/views/models.py
+++ b/daybed/views/models.py
@@ -36,6 +36,9 @@ acls = Service(name='model-acls',
                cors_origins=('*',))
 
 
+@definition.get(permission='get_definition',
+                accept='application/schema+json',
+                renderer='jsonschema')
 @definition.get(permission='get_definition')
 def get_definition(request):
     """Retrieves a model definition."""


### PR DESCRIPTION
- [x] Plug the new renderer with cornice;
- [x] Test that all the fields are supported;
- [x] Decide on a mime type to use.
- [ ] Accept JSON schema for definitions.

Here are the types supported by Daybed that we need to convert to JSON Schema:
- [x] Integer
- [x] Text
- [x] Datetime
- [x] Boolean
- [x] Regex
- [ ] JSON
- [ ] Anyof
- [x] Email
- [ ] OneOf
- [x] String
- [ ] Object
- [ ] Date
- [x] Url
- [ ] List
- [ ] Choices
- [x] Range

GeoTypes:
- [ ] Point
- [ ] Polygon
- [ ] GeoJSON
- [ ] Line
