### PR TITLE
Fix the annotation field implementation.

### DIFF
--- a/daybed/schemas/__init__.py
+++ b/daybed/schemas/__init__.py
@@ -82,7 +82,7 @@ class TypeField(object):
     def definition(cls, **kwargs):
         schema = SchemaNode(Mapping())
 
-        if kwargs.get('named', True) and getattr(cls, "named", True):
+        if kwargs.get('named', True):
             schema.add(SchemaNode(String(), name='name',
                        validator=Regex(r'^[a-zA-Z][a-zA-Z0-9_\-]*$')))
 

--- a/daybed/schemas/__init__.py
+++ b/daybed/schemas/__init__.py
@@ -80,7 +80,7 @@ class TypeField(object):
 
     @classmethod
     def definition(cls, **kwargs):
-        schema = SchemaNode(Mapping())
+        schema = SchemaNode(Mapping(unknown="preserve"))
 
         if kwargs.get('named', True):
             schema.add(SchemaNode(String(), name='name',

--- a/daybed/schemas/base.py
+++ b/daybed/schemas/base.py
@@ -18,7 +18,8 @@ from colander import (
     Email,
     Date,
     DateTime,
-    drop
+    Mapping,
+    drop,
 )
 
 from . import registry, TypeField, TypeFieldNode
@@ -52,15 +53,15 @@ class TextField(TypeField):
 
 @registry.add('annotation')
 class AnnotationField(TypeField):
-    named = False
     required = False
 
     @classmethod
     def definition(cls, **kwargs):
-        schema = super(AnnotationField, cls).definition(**kwargs)
-        # Keep the ``type`` node only
-        schema.children = [c for c in schema.children
-                           if c.name not in ('hint', 'name', 'required')]
+        schema = SchemaNode(Mapping(unknown="preserve"))
+
+        schema.add(SchemaNode(String(), name='label', missing=u''))
+        schema.add(SchemaNode(String(), name='type',
+                              validator=OneOf(["annotation"])))
         return schema
 
 

--- a/daybed/tests/test_functional.py
+++ b/daybed/tests/test_functional.py
@@ -279,6 +279,7 @@ class AnnotationModelTest(BaseWebTest):
                     {
                         "type": "annotation",
                         "label": "The annotation item",
+                        "anotherField": "haha"
                     }
                 ]
             }
@@ -287,4 +288,7 @@ class AnnotationModelTest(BaseWebTest):
         resp = self.app.get('/models/annotation', headers=self.headers)
         self.assertEquals(
             resp.json['definition']['fields'][0],
-            {u'label': u'The annotation item', u'type': u'annotation'})
+            {u'label': u'The annotation item',
+             u'type': u'annotation',
+             u'anotherField': u'haha'
+            })

--- a/daybed/tests/test_functional.py
+++ b/daybed/tests/test_functional.py
@@ -177,7 +177,8 @@ class TodoModelTest(FunctionalTest, BaseWebTest):
                         "todo"
                     ],
                     "required": True,
-                    "label": "is it done or not"
+                    "label": "is it done or not",
+                    "display": "dropdown"
                 }
             ]
         }
@@ -192,6 +193,11 @@ class TodoModelTest(FunctionalTest, BaseWebTest):
 
     def update_record(self, entry):
         entry['status'] = 'done'
+
+    def test_definition_creation_does_keep_metadata_fields(self):
+        resp = self.app.get('/models/%s/definition' % self.model_id,
+                            headers=self.headers)
+        self.assertEquals(resp.json["fields"][1]["display"], "dropdown")
 
 
 class MushroomsModelTest(FunctionalTest, BaseWebTest):
@@ -288,7 +294,9 @@ class AnnotationModelTest(BaseWebTest):
         resp = self.app.get('/models/annotation', headers=self.headers)
         self.assertEquals(
             resp.json['definition']['fields'][0],
-            {u'label': u'The annotation item',
-             u'type': u'annotation',
-             u'anotherField': u'haha'
-            })
+            {
+                u'label': u'The annotation item',
+                u'type': u'annotation',
+                u'anotherField': u'haha'
+            }
+        )


### PR DESCRIPTION
Without this change, especially the "unknown='preserve'" options passed to the
Mapping class, all the values passed in addition to the authorized ones would
be dropped, and that's not what we want, because having arbitrary values is
helpful to add information specific to the business logic.
