### PR TITLE
Accept an extra property to models definition to put other model related informations.

### DIFF
--- a/daybed/schemas/validators.py
+++ b/daybed/schemas/validators.py
@@ -6,7 +6,7 @@ import datetime
 
 import six
 from colander import (
-    SchemaNode, Mapping, Sequence, Length, String, null, Invalid, OneOf
+    SchemaNode, Mapping, Sequence, Length, String, null, Invalid, OneOf, drop
 )
 from pyramid.security import Authenticated, Everyone
 
@@ -21,6 +21,8 @@ class DefinitionSchema(SchemaNode):
         super(DefinitionSchema, self).__init__(Mapping(), *args, **kwargs)
         self.add(SchemaNode(String(), name='title'))
         self.add(SchemaNode(String(), name='description'))
+        self.add(SchemaNode(Mapping(unknown="preserve"),
+                            name="extra", missing=drop))
         self.add(SchemaNode(Sequence(), SchemaNode(TypeFieldNode()),
                             name='fields', validator=Length(min=1)))
 

--- a/daybed/tests/test_schemas_validators.py
+++ b/daybed/tests/test_schemas_validators.py
@@ -138,6 +138,8 @@ class DefinitionSchemaTest(unittest.TestCase):
             ]
         })
         self.assertIn("extra", definition)
+        self.assertIn("submitButtonLabel", definition["extra"])
+        self.assertEqual("Let's go!", definition["extra"]["submitButtonLabel"])
 
     def test_extra_may_not_be_present(self):
         schema = validators.DefinitionSchema()

--- a/daybed/tests/test_schemas_validators.py
+++ b/daybed/tests/test_schemas_validators.py
@@ -124,6 +124,33 @@ class DefinitionSchemaTest(unittest.TestCase):
         validator = schemas.AnnotationField.validation(**definition)
         self.assertEquals(colander.null, validator.deserialize(''))
 
+    def test_extra_may_be_present(self):
+        schema = validators.DefinitionSchema()
+        definition = schema.deserialize({
+            "title": "Foobar",
+            "description": "foo bar",
+            "extra": {
+                "submitButtonLabel": "Let's go!",
+            },
+            "fields": [
+                {'type': 'annotation',
+                 'label': 'this is some content'}
+            ]
+        })
+        self.assertIn("extra", definition)
+
+    def test_extra_may_not_be_present(self):
+        schema = validators.DefinitionSchema()
+        definition = schema.deserialize({
+            "title": "Foobar",
+            "description": "foo bar",
+            "fields": [
+                {'type': 'annotation',
+                 'label': 'this is some content'}
+            ]
+        })
+        self.assertNotIn("extra", definition)
+
 
 class ModelSchemaTest(unittest.TestCase):
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -142,7 +142,7 @@ The definition properties are:
 * **title**: The model title
 * **description**: The model description
 * **fields**: The model fields' list. See :ref:`fields documentation <fieldtypes-section>`
-* **extra**: An optional mapping to link some more information to your model.
+* **extra**: An optional property to store custom data to your model.
 
 
 **GET /models**

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -137,6 +137,14 @@ Of course, the model permissions can be changed later.
     by a **POST**. A random name will be generated.
 
 
+The definition properties are:
+
+* **title**: The model title
+* **description**: The model description
+* **fields**: The model fields' list. See :ref:`fields documentation <fieldtypes-section>`
+* **extra**: An optional mapping to link some more information to your model.
+
+
 **GET /models**
 
 Returns the list of models where you have the permission to read the definition::


### PR DESCRIPTION
Fix the Formbuilder error with `submitButtonLabel`
