### PR TITLE
Add {posargs} to tox to provide params to nosetests after '--'

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py26,py27,py34,pypy,flake8
 [testenv]
 commands =
     python --version
-    nosetests --with-coverage --cover-package=daybed
+    nosetests --with-coverage --cover-package=daybed {posargs}
 deps =
     coverage
     nose


### PR DESCRIPTION
This allows to pass parameters to nosetests after a `--`, like so:

`tox -e py26 -- daybed.tests.test_views --pdb`
